### PR TITLE
Add safe_json filter and meta=true request

### DIFF
--- a/lib/jekyll/attendease_plugin/event_data_generator.rb
+++ b/lib/jekyll/attendease_plugin/event_data_generator.rb
@@ -68,7 +68,7 @@ module Jekyll
                 options.merge!(:headers => {'X-Event-Token' => @attendease_config['access_token']}) if @attendease_config['access_token']
 
                 request_filename = file_name.gsub(/yml$/, 'yaml')
-                response = get("#{@attendease_config['api_host']}api/#{request_filename}", options)
+                response = get("#{@attendease_config['api_host']}api/#{request_filename}?meta=true", options)
 
                 #if (file_name.match(/yaml$/) || data.is_a?(Hash) && !data['error']) || data.is_a?(Array)
                 if (!response.nil? && response.response.is_a?(Net::HTTPOK))

--- a/lib/jekyll/attendease_plugin/filters.rb
+++ b/lib/jekyll/attendease_plugin/filters.rb
@@ -4,19 +4,8 @@ module Jekyll
       def slugify(string)
         Helpers.parameterize(string, '_')
       end
-
       def json(obj)
         obj.to_json
-      end
-
-      def safe_json(obj)
-        obj = obj.to_json
-        obj.gsub!(/[^\x00-\x7F]/,'')             # escape non-ascii
-        obj.gsub!(/\\[nrt]/,'')                  # escape multiline
-        obj.gsub!('\"','escaped-quotes')         # escape content quotes I
-        obj.gsub!('"','\"')                      # escape quoting quotes
-        obj.gsub!('escaped-quotes','\\\\\\\\\"') # escape content quotes II
-        obj
       end
     end
   end

--- a/lib/jekyll/attendease_plugin/filters.rb
+++ b/lib/jekyll/attendease_plugin/filters.rb
@@ -4,8 +4,19 @@ module Jekyll
       def slugify(string)
         Helpers.parameterize(string, '_')
       end
+
       def json(obj)
         obj.to_json
+      end
+
+      def safe_json(obj)
+        obj = obj.to_json
+        obj.gsub!(/[^\x00-\x7F]/,'')             # escape non-ascii
+        obj.gsub!(/\\[nrt]/,'')                  # escape multiline
+        obj.gsub!('\"','escaped-quotes')         # escape content quotes I
+        obj.gsub!('"','\"')                      # escape quoting quotes
+        obj.gsub!('escaped-quotes','\\\\\\\\\"') # escape content quotes II
+        obj
       end
     end
   end

--- a/lib/jekyll/attendease_plugin/version.rb
+++ b/lib/jekyll/attendease_plugin/version.rb
@@ -1,5 +1,5 @@
 module Jekyll
   module AttendeasePlugin
-    VERSION = '0.6.19'
+    VERSION = '0.6.20.pre'
   end
 end


### PR DESCRIPTION
Connect #75

The `safe_json` filter allows to safely output json strings in javascript code to be parsed later, without any errors. Non ascii-characters, as well as line jump characters are removed, inside/outside quotes are escaped.

Usage example
```javascript
<script type="text/javascript">
  Attendease.apiRoot    = '{{ site.attendease.api_host }}';
  // Load Attendease objects
  Attendease.presenters = JSON.parse("{{ site.attendease.presenters | safe_json }}");
  Attendease.venues     = JSON.parse("{{ site.attendease.venues     | safe_json }}");
  Attendease.rooms      = JSON.parse("{{ site.attendease.rooms      | safe_json }}");
  Attendease.filters    = JSON.parse("{{ site.attendease.filters    | safe_json }}");
  Attendease.sessions   = JSON.parse("{{ site.attendease.sessions   | safe_json }}");
  Attendease.instances = Attendease.sessions.map(function(session){
    return session.instances.map(function(instance){
      instance.session = session;
      return instance;
    })
  }).reduce(function(a, b) {
    return a.concat(b);
  }, []);
</script>
```