### PR TITLE
Allow sites to publish the cached event JSON data

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,1 +1,3 @@
 sudo: false
+gemfile:
+  - Gemfile.travisci

--- a/Gemfile.travisci
+++ b/Gemfile.travisci
@@ -1,0 +1,13 @@
+# vim: ft=ruby
+source 'https://rubygems.org'
+
+gem 'httparty',  '~> 0.13.5'
+gem 'json',      '~> 1.8.1'
+gem 'i18n',      '~> 0.6.9'
+gem 'redcarpet', '~> 2.3.0'
+
+gem 'bundler'
+gem 'rake'
+gem 'rspec'
+gem 'jekyll', '1.5.1'
+gem 'coveralls'

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ presenter_page_title        | Presenter: %s      | %s will be substituted with t
 venues_index_title          | Venues             | Override to set the page.title property of the Venues index page
 venue_page_title            | Venue: %s          | %s will be substituted with venue's name. Override to set the page.title property of the individual Venue page
 session_slug_uses_code      | false              | If true, the slugs used for session pages.
+copy_data                   | false              | If true, the API-provided data gets copied to an 'attendease_data' folder which will be available for consumption by your Javascript
 
 Remember to replace `https://your-event-subdomain.attendease.com/` with your actual event url, or crazy things will happen!
 

--- a/lib/jekyll-attendease.rb
+++ b/lib/jekyll-attendease.rb
@@ -1,7 +1,7 @@
 require 'jekyll'
 begin
   require 'httparty'
-rescue
+rescue LoadError
   # work around TravisCI issue
 end
 require 'json'

--- a/lib/jekyll-attendease.rb
+++ b/lib/jekyll-attendease.rb
@@ -1,9 +1,5 @@
 require 'jekyll'
-begin
-  require 'httparty'
-rescue LoadError
-  # work around TravisCI issue
-end
+require 'httparty'
 require 'json'
 require 'i18n'
 

--- a/lib/jekyll-attendease.rb
+++ b/lib/jekyll-attendease.rb
@@ -1,5 +1,9 @@
 require 'jekyll'
-require 'httparty'
+begin
+  require 'httparty'
+rescue
+  # work around TravisCI issue
+end
 require 'json'
 require 'i18n'
 

--- a/lib/jekyll/attendease_plugin/event_data_generator.rb
+++ b/lib/jekyll/attendease_plugin/event_data_generator.rb
@@ -115,6 +115,11 @@ module Jekyll
             event = JSON.parse(File.read("#{@attendease_data_path}/event.json"))
             site.config['attendease']['event'] = event
 
+            if @attendease_config['copy_data']
+              FileUtils.cp_r(@attendease_data_path, File.join(site.source, 'attendease_data'))
+              # tell Jekyll about these new static files to publish
+              site.read_directories 'attendease_data'
+            end
           end
 
         else

--- a/lib/jekyll/attendease_plugin/version.rb
+++ b/lib/jekyll/attendease_plugin/version.rb
@@ -1,5 +1,5 @@
 module Jekyll
   module AttendeasePlugin
-    VERSION = '0.6.20'
+    VERSION = '0.6.21'
   end
 end


### PR DESCRIPTION
With a configuration option in `_config.yml` of:

```
attendease:
  copy_data: true
```

The plug-in will include all of the event data JSON in an `attendease_data` folder in the published site. This allows a site's Javascript to load in this data via AJAX calls instead of baking the data into the HTML:

```
$.ajax('/attendease_data/presenters.json')
```

Note that your webserver should be configured to serve .json files with a MIME type of `application/json`.