### PR TITLE
Expose organization site settings to event

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    jekyll-attendease (0.6.27.1)
+      jekyll-attendease (0.6.28)
       awesome_print
       httparty (~> 0.13)
       i18n (~> 0.6.9)
@@ -10,7 +10,7 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    awesome_print (1.7.0)
+    awesome_print (1.8.0)
     coderay (1.1.1)
     colorator (0.1)
     coveralls (0.8.2)
@@ -107,4 +107,4 @@ DEPENDENCIES
   rspec
 
 BUNDLED WITH
-   1.14.4
+   1.15.0

--- a/lib/jekyll/attendease_plugin/event_data_generator.rb
+++ b/lib/jekyll/attendease_plugin/event_data_generator.rb
@@ -34,7 +34,7 @@ module Jekyll
           FileUtils.mkdir_p(@attendease_data_path)
 
           if site.config.cms_theme?
-            data_files = %w{ site event pages portal_pages site_settings }.map { |m| "#{m}.json"} << 'lingo.yml'
+            data_files = %w{ site event pages portal_pages site_settings organization_site_settings }.map { |m| "#{m}.json"} << 'lingo.yml'
           else
             data_files = %w{ site event sessions presenters rooms filters venues sponsors pages site_settings }.map { |m| "#{m}.json"} << 'lingo.yml'
           end

--- a/lib/jekyll/attendease_plugin/version.rb
+++ b/lib/jekyll/attendease_plugin/version.rb
@@ -1,5 +1,5 @@
 module Jekyll
   module AttendeasePlugin
-    VERSION = '0.6.27.1'
+    VERSION = '0.6.28'
   end
 end

--- a/spec/fixtures/_attendease/data/organization_site_settings.json
+++ b/spec/fixtures/_attendease/data/organization_site_settings.json
@@ -1,0 +1,23 @@
+{
+    "look_and_feel": {
+        "background_color": "",
+        "background_image": "",
+        "body_color": "",
+        "body_font_family": "serif",
+        "body_font_size": "10",
+        "body_font_style": "",
+        "custom_css": "",
+        "favicon": "",
+        "heading_color": {
+            "h1": "rgba(55,27,184,1)"
+        },
+        "heading_font_family": {
+            "h1": "sans-serif"
+        },
+        "heading_font_size": {
+            "h1": "18"
+        },
+        "heading_font_style": {},
+        "logo": ""
+    }
+}

--- a/spec/lib/jekyll/attendease_plugin/event_data_generator_spec.rb
+++ b/spec/lib/jekyll/attendease_plugin/event_data_generator_spec.rb
@@ -71,6 +71,11 @@ RSpec.describe Jekyll::AttendeasePlugin::EventDataGenerator do
       expect(site.data['site_settings']['look_and_feel']['body_font_family']).to eq('serif')
     end
 
+    it 'populates a site wide organization settings object' do
+      expect(site.data['organization_site_settings'].class).to eq(Hash)
+      expect(site.data['organization_site_settings']['look_and_feel']['heading_color']['h1']).to eq('rgba(55,27,184,1)')
+    end
+
     it 'does not populate a site wide sponsors array' do
       expect(site.data['sponsors']).to be_nil
     end


### PR DESCRIPTION
Context: 
https://app.clubhouse.io/attendease/story/5913/expose-organization-site-settings-to-event-site-so-the-event-site-can-properly-render-the-portal-navigation

Changes to `jekyll-attendease` to support bringing in `organization_site_settings`

To test, please see notes to test include in: https://github.com/coverall/Attendease/pull/8407
