### PR TITLE
 Filter root pages so only root page can be listed in the navigation menu

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    jekyll-attendease (0.6.36)
+    jekyll-attendease (0.6.37)
       awesome_print
       httparty (~> 0.13)
       i18n (~> 0.6.9)

--- a/README.md
+++ b/README.md
@@ -9,6 +9,9 @@ Status](https://coveralls.io/repos/attendease/jekyll-attendease/badge.svg?branch
 
 ## Changes
 
+### 0.6.37
+* Filter root pages so only root page can be listed in the navigation menu
+
 ### 0.6.36
 * Expose public pages and settings (only `parentPagesAreClickable` for now).
 

--- a/lib/jekyll/attendease_plugin/tags.rb
+++ b/lib/jekyll/attendease_plugin/tags.rb
@@ -163,6 +163,7 @@ module Jekyll
         page_keys = %w[id name href weight active root children parent]
 
         pages = context.registers[:site].data[page_data_source]
+          .select { |p| p['root'] }
           .reject { |p| p['hidden'] }
           .map do |page|
             page = page.select { |key| page_keys.include?(key) }

--- a/lib/jekyll/attendease_plugin/version.rb
+++ b/lib/jekyll/attendease_plugin/version.rb
@@ -1,5 +1,5 @@
 module Jekyll
   module AttendeasePlugin
-    VERSION = '0.6.36'
+    VERSION = '0.6.37'
   end
 end


### PR DESCRIPTION
This is needed because we can't filter those root page in the publish process since we need all pages data to be available in the jekyll website.

Without this fix, any child page would get a 404.