### PR TITLE
Only remove the site settings from the block renderer tag.

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,9 @@ Status](https://coveralls.io/repos/attendease/jekyll-attendease/badge.svg?branch
 
 ## Changes
 
+### 0.6.40.1
+* Don't include the general site settings (i.e. inline script code) in the block renderer tag
+
 ### 0.6.38.1
 * Expose site settings and portal pages to the event and organization websites
 

--- a/jekyll-attendease.gemspec
+++ b/jekyll-attendease.gemspec
@@ -5,7 +5,7 @@ require 'jekyll/attendease_plugin/version'
 Gem::Specification.new do |s|
   s.name          = 'jekyll-attendease'
   s.version       = Jekyll::AttendeasePlugin::VERSION
-  s.date          = '2018-09-25'
+  s.date          = '2018-10-11'
   s.summary       = 'Attendease event helper for Jekyll'
   s.description   = 'Bring your event data into Jekyll for amazing event websites.'
   s.authors       = [ 'Michael Wood', 'Patrick Gibson', 'Jamie Lubiner', 'Antoine Censi' ]

--- a/lib/jekyll/attendease_plugin/tags.rb
+++ b/lib/jekyll/attendease_plugin/tags.rb
@@ -151,14 +151,16 @@ module Jekyll
 
       def render(context)
         config = context.registers[:site].config['attendease']
-        siteSettings = context.registers[:site].data['site_settings'].delete_if {|key, value| ['analytics', 'meta'].include? key }
+        siteSettings = context.registers[:site].data['site_settings'].clone
+        siteSettings.delete_if {|key, value| ['analytics', 'meta', 'general'].include? key }
 
         organizationSiteSettings = {}
         if context.registers[:site].data['organization_site_settings']
-          organizationSiteSettings = context.registers[:site].data['organization_site_settings'].delete_if {|key, value| ['analytics', 'meta'].include? key }
+          organizationSiteSettings = context.registers[:site].data['organization_site_settings'].clone
+          organizationSiteSettings.delete_if {|key, value| ['analytics', 'meta', 'general'].include? key }
         end
 
-        parent_pages_are_clickable = config['parent_pages_are_clickable']        
+        parent_pages_are_clickable = config['parent_pages_are_clickable']
 
         page_keys = %w[id name href weight active root children parent]
 
@@ -198,10 +200,10 @@ module Jekyll
 
 
         env = config['environment']
-        
-        # IMPORTANT NOTE: The script variables below must NOT be changed without making sure that blockrenderer.js and other 
+
+        # IMPORTANT NOTE: The script variables below must NOT be changed without making sure that blockrenderer.js and other
         # related code in the platform is backwards-compatible.
-        
+
         if config['mode'] == 'organization'
           script = <<_EOT
 <script type="text/javascript">

--- a/lib/jekyll/attendease_plugin/version.rb
+++ b/lib/jekyll/attendease_plugin/version.rb
@@ -1,5 +1,5 @@
 module Jekyll
   module AttendeasePlugin
-    VERSION = '0.6.38.1'
+    VERSION = '0.6.40.1'
   end
 end


### PR DESCRIPTION
https://app.clubhouse.io/attendease/story/27029/jekyll-plugin-is-removing-items-from-site-settings-intended-to-be-removed-only-from-the-block-renderer-tag