### PR TITLE
Always show the home page on the pages array

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    jekyll-attendease (0.6.43.3)
+    jekyll-attendease (0.6.44)
       awesome_print
       httparty (~> 0.13)
       i18n (~> 0.6.9)
@@ -25,7 +25,7 @@ GEM
     docile (1.1.5)
     ffi (1.9.25)
     forwardable-extended (2.6.0)
-    httparty (0.16.3)
+    httparty (0.16.4)
       mime-types (~> 3.0)
       multi_xml (>= 0.5.2)
     i18n (0.6.11)

--- a/README.md
+++ b/README.md
@@ -9,6 +9,10 @@ Status](https://coveralls.io/repos/attendease/jekyll-attendease/badge.svg?branch
 
 ## Changes
 
+### 0.6.43.4
+
+* Always show the Home page object even if is hidden from the Navigation
+
 ### 0.6.43.3
 
 * Bug fix to the Google Analytics and Google Ads tag

--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@ Status](https://coveralls.io/repos/attendease/jekyll-attendease/badge.svg?branch
 
 ## Changes
 
-### 0.6.43.4
+### 0.6.44
 
-* Always show the Home page object even if is hidden from the Navigation
+* Include the home page in the `AttendeaseConstants.pages` array even if it is hidden.
 
 ### 0.6.43.3
 

--- a/lib/jekyll/attendease_plugin/helpers.rb
+++ b/lib/jekyll/attendease_plugin/helpers.rb
@@ -38,7 +38,7 @@ module Jekyll
                  fallback: lambda { |c| fallback.key?(c) ? fallback[c] : undefined })
       end
 
-      PAGE_KEYS = %w[id name href weight root children parent hidden external].freeze
+      PAGE_KEYS = %w[id name href weight root children parent hidden].freeze
 
       # filter the raw pages for what's safe to make public
       def self.public_pages(pages)

--- a/lib/jekyll/attendease_plugin/helpers.rb
+++ b/lib/jekyll/attendease_plugin/helpers.rb
@@ -38,10 +38,11 @@ module Jekyll
                  fallback: lambda { |c| fallback.key?(c) ? fallback[c] : undefined })
       end
 
-      PAGE_KEYS = %w[id name href weight root children parent hidden].freeze
+      PAGE_KEYS = %w[id name href weight root children parent hidden external].freeze
 
       # filter the raw pages for what's safe to make public
       def self.public_pages(pages)
+        return if pages.nil?
         pages
           .select { |p| p['root'] }
           .reject { |p| p['hidden'] && (p['slug'] != '' || p['external'] == true) }

--- a/lib/jekyll/attendease_plugin/helpers.rb
+++ b/lib/jekyll/attendease_plugin/helpers.rb
@@ -35,7 +35,27 @@ module Jekyll
                     'ø' => 'o', 'ù' => 'u', 'ú' => 'u', 'û' => 'u', 'ü' => 'u',
                     'ý' => 'y', 'ÿ' => 'y' }
         s.encode('ASCII',
-        fallback: lambda { |c| fallback.key?(c) ? fallback[c] : undefined })
+                 fallback: lambda { |c| fallback.key?(c) ? fallback[c] : undefined })
+      end
+
+      PAGE_KEYS = %w[id name href weight root children parent hidden].freeze
+
+      # filter the raw pages for what's safe to make public
+      def self.public_pages(pages)
+        pages
+          .select { |p| p['root'] }
+          .reject { |p| p['hidden'] && (p['slug'] != '' || p['external'] == true) }
+          .map do |page|
+            page = page.select { |key| PAGE_KEYS.include?(key) }
+
+            page['children'] = page['children']
+                               .reject { |p| p['hidden'] }
+                               .map { |child| child.select { |key| PAGE_KEYS.include?(key) } }
+                               .sort_by { |p| p['weight'] }
+
+            page
+          end
+          .sort_by { |p| p['weight'] }
       end
     end
   end

--- a/lib/jekyll/attendease_plugin/tags.rb
+++ b/lib/jekyll/attendease_plugin/tags.rb
@@ -168,7 +168,7 @@ module Jekyll
         pages = {}
         pages = context.registers[:site].data['pages']
           .select { |p| p['root'] }
-          .reject { |p| p['hidden'] }
+          .reject { |p| p['hidden'] && p['slug'] != '' }
           .map do |page|
             page = page.select { |key| page_keys.include?(key) }
 
@@ -185,7 +185,7 @@ module Jekyll
         if (context.registers[:site].data['portal_pages'])
           portal_pages = context.registers[:site].data['portal_pages']
             .select { |p| p['root'] }
-            .reject { |p| p['hidden'] }
+            .reject { |p| p['hidden'] && p['slug'] != '' }
             .map do |page|
               page = page.select { |key| page_keys.include?(key) }
 

--- a/lib/jekyll/attendease_plugin/tags.rb
+++ b/lib/jekyll/attendease_plugin/tags.rb
@@ -82,7 +82,6 @@ module Jekyll
       end
     end
 
-    #require 'pry'
     class PortalNavigationTag < Liquid::Block
       def initialize(tag_name, params, tokens)
         super
@@ -205,6 +204,7 @@ module Jekyll
             'analytics' => analytics
         }
         end
+
         script = <<_EOT
 <script type="text/javascript">
 (function(w) {

--- a/lib/jekyll/attendease_plugin/tags.rb
+++ b/lib/jekyll/attendease_plugin/tags.rb
@@ -163,43 +163,9 @@ module Jekyll
 
         parent_pages_are_clickable = config['parent_pages_are_clickable']
 
-        page_keys = %w[id name href weight active root children parent]
+        pages = Helpers.public_pages(context.registers[:site].data['pages'])
 
-        pages = {}
-        pages = context.registers[:site].data['pages']
-          .select { |p| p['root'] }
-          .reject { |p| p['hidden'] && p['slug'] != '' }
-          .map do |page|
-            page = page.select { |key| page_keys.include?(key) }
-
-            page['children'] = page['children']
-              .reject { |p| p['hidden'] }
-              .map { |child| child.select { |key| page_keys.include?(key) } }
-              .sort_by { |p| p['weight'] }
-
-            page
-          end
-          .sort_by { |p| p['weight'] }
-
-        portal_pages = {}
-        if (context.registers[:site].data['portal_pages'])
-          portal_pages = context.registers[:site].data['portal_pages']
-            .select { |p| p['root'] }
-            .reject { |p| p['hidden'] && p['slug'] != '' }
-            .map do |page|
-              page = page.select { |key| page_keys.include?(key) }
-
-              page['children'] = page['children']
-                .reject { |p| p['hidden'] }
-                .map { |child| child.select { |key| page_keys.include?(key) } }
-                .sort_by { |p| p['weight'] }
-
-              page
-            end
-            .sort_by { |p| p['weight'] }
-        end
-
-
+        portal_pages = Helpers.public_pages(context.registers[:site].data['portal_pages']) || []
         env = config['environment']
 
         # IMPORTANT NOTE: The script variables below must NOT be changed without making sure that blockrenderer.js and other

--- a/lib/jekyll/attendease_plugin/version.rb
+++ b/lib/jekyll/attendease_plugin/version.rb
@@ -1,5 +1,5 @@
 module Jekyll
   module AttendeasePlugin
-    VERSION = '0.6.43.4'
+    VERSION = '0.6.44'
   end
 end

--- a/lib/jekyll/attendease_plugin/version.rb
+++ b/lib/jekyll/attendease_plugin/version.rb
@@ -1,5 +1,5 @@
 module Jekyll
   module AttendeasePlugin
-    VERSION = '0.6.43.3'
+    VERSION = '0.6.43.4'
   end
 end

--- a/spec/fixtures/_attendease/data/pages.json
+++ b/spec/fixtures/_attendease/data/pages.json
@@ -190,7 +190,7 @@
         "id": "je541a28-f62c-435e-a1c0-477a6120f9b7",
         "page_key": "",
         "permanent": true,
-        "href": "",
+        "href": "https://attendease.com",
         "children": [],
         "root": true,
         "parent": null,

--- a/spec/fixtures/_attendease/data/pages.json
+++ b/spec/fixtures/_attendease/data/pages.json
@@ -36,7 +36,7 @@
         "name": "Agenda <script>alert()</script>",
         "top_level": true,
         "updated_at": "2016-10-21T18:06:53Z",
-        "weight": 1,
+        "weight": 2,
         "block_instances": [],
         "external": false,
         "external_url": null
@@ -47,7 +47,7 @@
         "name": "Product",
         "description": "The product page",
         "slug": "product",
-        "weight": 5,
+        "weight": 1,
         "active": true,
         "hidden": false,
         "permanent": false,
@@ -65,7 +65,7 @@
                 "name": "Product Child 1",
                 "description": "",
                 "slug": "product-child-1",
-                "weight": 0,
+                "weight": 1,
                 "active": true,
                 "hidden": false,
                 "permanent": false,
@@ -86,7 +86,7 @@
                 "name": "Product Child 2",
                 "description": "",
                 "slug": "product-child-2",
-                "weight": 1,
+                "weight": 0,
                 "active": true,
                 "hidden": false,
                 "permanent": false,
@@ -122,7 +122,7 @@
         "name": "Venues",
         "top_level": true,
         "updated_at": "2016-10-21T18:06:53Z",
-        "weight": 5,
+        "weight": 4,
         "block_instances": [],
         "external": false,
         "external_url": null
@@ -143,7 +143,7 @@
         "name": "Sponsors",
         "top_level": true,
         "updated_at": "2016-10-21T18:06:53Z",
-        "weight": 7,
+        "weight": 3,
         "block_instances": [],
         "external": false,
         "external_url": null
@@ -164,7 +164,7 @@
         "slug": "test",
         "top_level": true,
         "updated_at": "2016-11-15T19:22:19Z",
-        "weight": 9,
+        "weight": 6,
         "block_instances": [
             {
                 "id": 6,
@@ -198,7 +198,7 @@
         "name": "",
         "top_level": true,
         "updated_at": "2016-10-21T18:06:53Z",
-        "weight": 8,
+        "weight": 5,
         "block_instances": [],
         "external": true,
         "external_url": "https://attendease.com"

--- a/spec/lib/jekyll/attendease_plugin/helpers_spec.rb
+++ b/spec/lib/jekyll/attendease_plugin/helpers_spec.rb
@@ -65,5 +65,9 @@ RSpec.describe Jekyll::AttendeasePlugin::Helpers do
     it 'only has the declared keys in each page object' do
       expect(public_pages[0].keys.length).to eq(8)
     end
+
+    it 'handles nil input' do
+      expect(Jekyll::AttendeasePlugin::Helpers.public_pages(nil)).to be_nil
+    end
   end
 end

--- a/spec/lib/jekyll/attendease_plugin/helpers_spec.rb
+++ b/spec/lib/jekyll/attendease_plugin/helpers_spec.rb
@@ -2,7 +2,7 @@
 require 'spec_helper'
 
 RSpec.describe Jekyll::AttendeasePlugin::Helpers do
-  context '#parameterize' do
+  describe '#parameterize' do
     it 'converts a typical filter item into a predictable CSS-friendly class name' do
       expect(Jekyll::AttendeasePlugin::Helpers.parameterize('Super Hyper Advanced', '-')).to eq('super-hyper-advanced')
     end
@@ -21,6 +21,49 @@ RSpec.describe Jekyll::AttendeasePlugin::Helpers do
 
     it 'will strip leading and trailing separators' do
       expect(Jekyll::AttendeasePlugin::Helpers.parameterize('-, What--the--hell? ::')).to eq('what_the_hell')
+    end
+  end
+
+  describe '#convert_to_ascii' do
+    it 'converts accented characters to plain letters' do
+      expect(Jekyll::AttendeasePlugin::Helpers.convert_to_ascii('café')).to eq('cafe')
+    end
+  end
+
+  describe '#public_pages' do
+    let(:pages) { JSON.parse(File.read(fixtures_path.join('_attendease', 'data', 'pages.json'))) }
+    let(:public_pages) { Jekyll::AttendeasePlugin::Helpers.public_pages(pages) }
+    let(:all_pages_hidden) do
+      hidden_pages = pages.map { |p| p['hidden'] = true; p }
+      Jekyll::AttendeasePlugin::Helpers.public_pages(hidden_pages)
+    end
+
+    it 'sorts pages by weight' do
+      expect(public_pages[0]['weight']).to eq(0)
+      expect(public_pages[0]['href']).to eq('/')
+
+      expect(public_pages[1]['weight']).to eq(1)
+      expect(public_pages[1]['href']).to eq('/product/')
+
+      expect(public_pages[2]['weight']).to eq(2)
+      expect(public_pages[2]['href']).to eq('/agenda/')
+
+      expect(public_pages[3]['weight']).to eq(3)
+      expect(public_pages[3]['href']).to eq('/sponsors/')
+    end
+
+    it 'sorts children by weight' do
+      expect(public_pages[1]['children'][0]['name']).to eq('Product Child 2')
+      expect(public_pages[1]['children'][1]['name']).to eq('Product Child 1')
+    end
+
+    it 'publishes the home page regardless of hidden status' do
+      expect(all_pages_hidden.length).to eq(1)
+      expect(all_pages_hidden[0]['href']).to eq('/')
+    end
+
+    it 'only has the declared keys in each page object' do
+      expect(public_pages[0].keys.length).to eq(8)
     end
   end
 end


### PR DESCRIPTION
### Story

https://app.clubhouse.io/attendease/story/30707/page-titles-not-updating-in-certain-cases

### Description

- Update to gem `0.6.44` 
- Hide all pages with `hidden` attribute from the pages array except for the Home