### PR TITLE
Support for path-based events

### DIFF
--- a/lib/jekyll/attendease_plugin/tags.rb
+++ b/lib/jekyll/attendease_plugin/tags.rb
@@ -183,7 +183,8 @@ module Jekyll
             'pages' => pages,
             'settings' => { parentPagesAreClickable: !!parent_pages_are_clickable },
             'siteSettings' => site_settings,
-            'analytics' => analytics
+            'analytics' => analytics,
+            'basePath' => config['base_path']
           }
         else
           constants = {
@@ -201,7 +202,8 @@ module Jekyll
             'settings' => { parentPagesAreClickable: !!parent_pages_are_clickable },
             'siteSettings' => site_settings,
             'organizationSiteSettings' => organization_site_settings,
-            'analytics' => analytics
+            'analytics' => analytics,
+            'basePath' => config['base_path']
         }
         end
 

--- a/lib/jekyll/attendease_plugin/version.rb
+++ b/lib/jekyll/attendease_plugin/version.rb
@@ -1,6 +1,6 @@
 module Jekyll
   module AttendeasePlugin
-    VERSION = '0.9.5'
+    VERSION = '0.9.6'
   end
 end
 


### PR DESCRIPTION
Include the basePath for the site as it's needed by several things to opporate correctly when an event site is not at the root.